### PR TITLE
Nservicebus 10 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Setup dotnet 8.0
+    - name: Setup dotnet 10.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
     - name: Build and Test
       run: ./Build.ps1
       shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Setup dotnet 8.0
+    - name: Setup dotnet 10.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
     - name: Build and Test
       run: ./Build.ps1
       shell: pwsh

--- a/src/NServiceBus.Extensions.IntegrationTesting/EndpointConfigurationExtensions.cs
+++ b/src/NServiceBus.Extensions.IntegrationTesting/EndpointConfigurationExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using NServiceBus.Features;
 
 namespace NServiceBus.Extensions.IntegrationTesting
 {
@@ -36,7 +35,6 @@ namespace NServiceBus.Extensions.IntegrationTesting
 
             endpoint.PurgeOnStartup(true);
             endpoint.DisableFeature<Features.Audit>();
-            endpoint.EnableOpenTelemetry();
 
             endpoint.Pipeline.Register(
                 new AttachIncomingLogicalMessageContextToActivity(),

--- a/src/NServiceBus.Extensions.IntegrationTesting/NServiceBus.Extensions.IntegrationTesting.csproj
+++ b/src/NServiceBus.Extensions.IntegrationTesting/NServiceBus.Extensions.IntegrationTesting.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Authors>Jimmy Bogard</Authors>
     <Copyright>Jimmy Bogard</Copyright>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="[9.0.0, 10.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[10.0.0, 11.0.0)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.Extensions.IntegrationTesting/NServiceBus.Extensions.IntegrationTesting.csproj
+++ b/src/NServiceBus.Extensions.IntegrationTesting/NServiceBus.Extensions.IntegrationTesting.csproj
@@ -17,8 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[10.0.0, 11.0.0)" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.102" PrivateAssets="All" />
+    <PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/tests/NServiceBus.Extensions.IntegrationTesting.Tests/HostApplicationFactoryTests.cs
+++ b/tests/NServiceBus.Extensions.IntegrationTesting.Tests/HostApplicationFactoryTests.cs
@@ -152,7 +152,8 @@ namespace NServiceBus.Extensions.IntegrationTesting.Tests
             protected override void ConfigureHowToFindSaga(SagaPropertyMapper<SagaData> mapper)
             {
                 //note that mapping on a string is the worst example ever
-                mapper.ConfigureMapping<StartSagaMessage>(m => m.Message).ToSaga(s => s.Message);
+                mapper.MapSaga(saga => saga.Message)
+                    .ToMessage<StartSagaMessage>(m => m.Message);
             }
 
             public Task Handle(StartSagaMessage message, IMessageHandlerContext context)

--- a/tests/NServiceBus.Extensions.IntegrationTesting.Tests/NServiceBus.Extensions.IntegrationTesting.Tests.csproj
+++ b/tests/NServiceBus.Extensions.IntegrationTesting.Tests/NServiceBus.Extensions.IntegrationTesting.Tests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.15" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.2" />
     <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/NServiceBus.Extensions.IntegrationTesting.Tests/NServiceBus.Extensions.IntegrationTesting.Tests.csproj
+++ b/tests/NServiceBus.Extensions.IntegrationTesting.Tests/NServiceBus.Extensions.IntegrationTesting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.15" />
-    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="3.0.1" />
+    <PackageReference Include="NServiceBus.Extensions.Hosting" Version="4.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">


### PR DESCRIPTION
This PR includes some (minor) changes to ensure NServiceBus 10 compatibility. This includes an update to .Net 10.
Additionally, all dependencies were updates to their latest version.